### PR TITLE
Preserve VybeScore history during publish

### DIFF
--- a/.github/workflows/publish-vybescore.yml
+++ b/.github/workflows/publish-vybescore.yml
@@ -36,6 +36,13 @@ jobs:
           repository: acoliver/evals
           path: evals
 
+      - name: Prime public artifacts with previous publish
+        run: |
+          mkdir -p evals/public
+          if [ -d vybescore ]; then
+            rsync -a vybescore/ evals/public/
+          fi
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The workflow in `.github/workflows/publish-vybescore.yml` runs every 4 hours (an
 2. Install the latest `@vybestack/llxprt-code` CLI plus evaluation dependencies
 3. Run `npm run eval:all` inside the evals repo using env-driven LLxprt configs
 4. Build the dashboard artifacts via `npm run build:vybes`
-5. Sync the generated `public/` folder to `vybescore/` and commit/push if anything changed
+5. Merge the previously published dashboard (copied from `vybescore/`) with the new results, then sync the refreshed `public/` folder to `vybescore/` and commit/push if anything changed
 
 ### Required Secrets
 


### PR DESCRIPTION
## Summary\n- copy the previous `vybescore/` payload into the evals repo before running `build:vybes` so the builder can merge past runs\n- update README to mention the merge step\n\nThis works with the updated `build-vybes` logic that merges new runs into existing JSON, so each publish accumulates history instead of overwriting it.