### PR TITLE
Fix sort arrow glyphs on VybeScore

### DIFF
--- a/vybescore/vybestack.css
+++ b/vybescore/vybestack.css
@@ -320,18 +320,18 @@ th.sortable {
 }
 
 th.sortable::after {
-  content: '\\2195';
+  content: '\2195';
   font-size: 0.8rem;
   margin-left: 0.4rem;
   opacity: 0.65;
 }
 
 th.sortable.asc::after {
-  content: '\\2191';
+  content: '\2191';
 }
 
 th.sortable.desc::after {
-  content: '\\2193';
+  content: '\2193';
 }
 
 .numeric,


### PR DESCRIPTION
## Summary\n- use actual Unicode escape sequences (\2195/\2191/\2193) in CSS so the headers show the arrow icons instead of the literal text\n\nNo dashboard markup changes required—just the stylesheet.