### PR TITLE
Fix VybeScore day labels

### DIFF
--- a/vybescore/index.html
+++ b/vybescore/index.html
@@ -146,7 +146,10 @@
       const rows = [];
       entries.forEach((entry) => {
         if (!entry) return;
-        const dayLabel = entry.date === 'unknown' ? 'Unknown Date' : entry.date;
+        const dayLabel =
+          entry.date === 'unknown'
+            ? 'Unknown Date'
+            : dayFormatter.format(new Date(`${entry.date}T00:00:00Z`));
         const profiles = Object.entries(entry.profiles);
         profiles.forEach(([configId, stats]) => {
           rows.push({
@@ -391,7 +394,7 @@
           const label =
             group.date === 'unknown'
               ? 'Unknown Date'
-              : dayFormatter.format(firstTimestamp ? new Date(firstTimestamp) : new Date(`${group.date}T00:00:00Z`));
+              : dayFormatter.format(new Date(`${group.date}T00:00:00Z`));
           const totalMinutes = group.runs.reduce((sum, run) => sum + (run.actualTimeMinutes ?? 0), 0);
           const profiles = [...new Set(group.runs.map((run) => run.profileLabel))].join(', ');
           const versions = [...new Set(group.runs.map((run) => run.repoVersion).filter(Boolean))];


### PR DESCRIPTION
## Summary\n- show formatted dates (via Intl.DateTimeFormat) instead of raw ISO strings in the Daily Overview table\n- use the same formatted date for each day section so the label doesn’t depend on whatever run finished last\n\nThis keeps the order (latest day first) but ensures the date text doesn’t flicker to the current day.